### PR TITLE
Remove auto-redirect; add 'view resume' button to user card

### DIFF
--- a/assets/javascripts/discourse/initializers/debaleena-discourse.js.es6
+++ b/assets/javascripts/discourse/initializers/debaleena-discourse.js.es6
@@ -1,30 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import User from "discourse/models/user";
 function initializePlugin(api) {
-	api.modifyClass('component:user-card-contents', {
-		_showCallback(username, $target) {
-			if(this.siteSettings.redirect_on_profile_picture){
-				var redirectUrl  =  this.siteSettings.redirect_avataar_external_website;
-				window.location.assign(redirectUrl.replace("{username}", username ))
-				return false;	
-			}else{
-				return this._super(username, $target);
-			}
-		}
-	});
-	api.modifyClass('controller:user-card', {
-		actions: {
-			showUser(user) {
-				if(this.siteSettings.redirect_on_profile_picture){
-					var redirectUrl  =  this.siteSettings.redirect_avataar_external_website;
-					window.location.assign(redirectUrl.replace("{username}", user.username ))	
-				}else{
-					this._super(user);	
-				}
-				
-			}
-		}
-	});
 	api.modifyClass('route:about', {
 		model() {
 			if(this.currentUser && this.currentUser.admin){

--- a/assets/javascripts/discourse/templates/connectors/user-card-before-badges/stemaway-profile-link.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-card-before-badges/stemaway-profile-link.hbs
@@ -1,0 +1,7 @@
+{{
+  d-button
+  class="btn-default"
+  href=(concat "https://1-click.stemaway.com/" this.user.username)
+  icon="user"
+  translatedLabel="View resume"
+}}

--- a/assets/javascripts/discourse/templates/connectors/user-card-before-badges/stemaway-profile-link.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-card-before-badges/stemaway-profile-link.hbs
@@ -1,7 +1,7 @@
 {{
   d-button
   class="btn-default"
-  href=(concat "https://1-click.stemaway.com/" this.user.username)
+  href=(concat (i18n "stemaway.oneClickUrl") this.user.username)
   icon="user"
-  translatedLabel="View resume"
+  translatedLabel=(i18n "stemaway.viewResume")
 }}

--- a/assets/stylesheets/stemaway-profile-link.css
+++ b/assets/stylesheets/stemaway-profile-link.css
@@ -1,0 +1,4 @@
+.stemaway-profile-link {
+  float: left;
+  margin: 7px 7px 0 0;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,5 @@
+en:
+  js:
+    stemaway:
+      oneClickUrl: https://1-click.stemaway.com/
+      viewResume: View resume

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,0 @@
-en:
-  site_settings:
-    redirect_avataar_external_website: "External website To Redirect To"
-    redirect_on_profile_picture: "Redirect On Profile Picture"
-

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,0 @@
-plugins:
-  redirect_avataar_external_website:
-    default: ""
-    client: true
-  redirect_on_profile_picture:
-    default: true
-    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,3 +3,5 @@
 # version: 0.1
 enabled_site_setting :redirect_on_profile_picture
 enabled_site_setting :redirect_avataar_external_website
+
+register_asset "stylesheets/stemaway-profile-link.css"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,4 @@
 # name: debaleena-discourse
 # about: Debaleena Discourse
 # version: 0.1
-enabled_site_setting :redirect_on_profile_picture
-enabled_site_setting :redirect_avataar_external_website
-
 register_asset "stylesheets/stemaway-profile-link.css"


### PR DESCRIPTION
This removes the auto-redirect which occurred on clicking a user card, and replaces it with a button on the user card to redirect to the resume in question.

<img width="441" alt="Captura de Pantalla 2020-06-17 a la(s) 7 33 19 p  m" src="https://user-images.githubusercontent.com/750477/84868874-6eb17b00-b0d1-11ea-920d-3713d6323c2f.png">

NB that this removes the existing site settings, so we'd need to change the translation file in order to change the stemaway link (although it's unlikely to change very often!)